### PR TITLE
conversion-script: fix repeated download of images

### DIFF
--- a/conversion-script.sh
+++ b/conversion-script.sh
@@ -236,12 +236,24 @@ cd ..
 if [ -n "$CREATE_JPG" ];then
     cd pictures-jpg
     create_symlink jpg
-    wget https://raw.githubusercontent.com/freifunk-darmstadt/gluon-firmware-selector/master/pictures/no_picture_available.jpg
-    wget https://raw.githubusercontent.com/freifunk-darmstadt/gluon-firmware-selector/master/pictures/x86-generic.img.jpg
-    wget https://raw.githubusercontent.com/freifunk-darmstadt/gluon-firmware-selector/master/pictures/x86-kvm.img.jpg
-    wget https://raw.githubusercontent.com/freifunk-darmstadt/gluon-firmware-selector/master/pictures/x86-legacy.img.jpg
-    wget https://raw.githubusercontent.com/freifunk-darmstadt/gluon-firmware-selector/master/pictures/x86-virtualbox.vdi.jpg
-    wget https://raw.githubusercontent.com/freifunk-darmstadt/gluon-firmware-selector/master/pictures/x86-vmware.vmdk.jpg
+
+    declare -a placeholder_images=(
+        "no_picture_available.jpg"
+        "x86-generic.img.jpg"
+        "x86-kvm.img.jpg"
+        "x86-legacy.img.jpg"
+        "x86-virtualbox.vdi.jpg"
+        "x86-vmware.vmdk.jpg"
+    )
+    for file in "${placeholder_images[@]}"
+    do
+        if [[ -f "${file}" ]]; then
+            echo "Skipping existing file ${file}"
+            continue
+        fi
+        wget "https://raw.githubusercontent.com/freifunk-darmstadt/gluon-firmware-selector/master/pictures/${file}"
+    done
+
     cd ..
     cd pictures-png
     create_symlink png


### PR DESCRIPTION
wget downloads images with the postfix ".1", ".2", etc for repeated downloads. The script allows downloading images only once (assuming they are correct).