### PR TITLE
conversion-script: should create optimized low resolution jpgs

### DIFF
--- a/conversion-script.sh
+++ b/conversion-script.sh
@@ -93,6 +93,6 @@ for file in pictures-svg/*.svg; do
         # as not all SVG are updated to have no borders, trim unnecessary white borders from png
         mogrify -trim "pictures-png/$normalized.png"
         # even though mogrify trims the png, we need to trim again for the jpg
-        convert "pictures-png/$normalized.png" -background white -flatten -alpha off -trim "pictures-jpg/$normalized.jpg"
+        convert "pictures-png/$normalized.png" -resize 256x256 -background white -flatten -alpha off -trim "pictures-jpg/$normalized.jpg"
     fi
 done;


### PR DESCRIPTION
As noted by @herbetom - here: https://github.com/freifunk-darmstadt/gluon-firmware-selector/pull/155#issuecomment-1820869873
the jpgs from the gluon-firmware-selector are downscaled to 256x256 pixels.
This decreases the total folder size of pictures-jpg to ~1.6MB

Should we also do this for pngs?