### PR TITLE
add Github Actions workflow for image generation

### DIFF
--- a/.github/workflows/generate-images.yml
+++ b/.github/workflows/generate-images.yml
@@ -1,0 +1,45 @@
+---
+name: Generate Images
+
+on:  # yamllint disable-line rule:truthy
+  workflow_dispatch:
+  workflow_call:
+
+jobs:
+  conversion:
+    name: Generate Images
+    runs-on: ubuntu-latest
+    container:
+      image: linuxserver/inkscape:1.3.2
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: install dependencies
+        run: |
+            apk --no-cache add imagemagick
+            apk --no-cache add exiftool
+
+      - name: convert images
+        run: |
+            ./conversion-script.sh
+
+      - name: package images
+        shell: bash
+        run: |
+            # The tar is required to preserve symlinks
+            tar cvf device-pictures-jpg.tar README.md pictures-jpg/
+            tar cvf device-pictures-png.tar README.md pictures-png/
+
+      - name: upload JPG archive
+        uses: actions/upload-artifact@v4
+        with:
+          name: device-pictures-jpg.tar
+          if-no-files-found: error
+          path: device-pictures-jpg.tar
+
+      - name: upload PNG archive
+        uses: actions/upload-artifact@v4
+        with:
+          name: device-pictures-png.tar
+          if-no-files-found: error
+          path: device-pictures-png.tar

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -3,14 +3,11 @@ name: Shell Linting
 
 on:  # yamllint disable-line rule:truthy
   workflow_dispatch:
-  push:
-    paths-ignore:
-      - '.github/workflows/**'
-      - '**.svg'
   pull_request:
     paths-ignore:
       - '.github/workflows/**'
       - '**.svg'
+  workflow_call:
 
 jobs:
   shellcheck:
@@ -26,3 +23,4 @@ jobs:
           filter_mode: "file"
           fail_on_error: true
           check_all_files_with_shebangs: true
+          reporter: github-check

--- a/.github/workflows/svglint.yml
+++ b/.github/workflows/svglint.yml
@@ -3,12 +3,10 @@
 
     on:  # yamllint disable-line rule:truthy
       workflow_dispatch:
-      push:
-        paths:
-          - '**.svg'
       pull_request:
         paths:
           - '**.svg'
+      workflow_call:
 
     jobs:
       svglint:

--- a/.github/workflows/test-and-generate-images.yml
+++ b/.github/workflows/test-and-generate-images.yml
@@ -1,0 +1,21 @@
+---
+on:
+  workflow_dispatch:
+  push:
+    paths-ignore:
+      - '.gitignore'
+    branches:
+      - main
+
+jobs:
+  shellcheck:
+    uses: ./.github/workflows/shellcheck.yml
+
+  svglint:
+    uses: ./.github/workflows/svglint.yml
+
+  generate-images:
+    needs:
+        - shellcheck
+        - svglint
+    uses: ./.github/workflows/generate-images.yml


### PR DESCRIPTION
This adds a Github Actions workflow that is run whenever there is a push to main to generate image artifacts.

This can later be expanded to add image artifacts to releases.