### PR TITLE
downsize pngs as well

### DIFF
--- a/conversion-script.sh
+++ b/conversion-script.sh
@@ -43,6 +43,7 @@ for file in pictures-svg/*.svg; do
         mogrify -trim "pictures-png/$normalized.png"
         # even though mogrify trims the png, we need to trim again for the jpg
         convert "pictures-png/$normalized.png" -resize 65536@\> -background white -flatten -alpha off -trim "pictures-jpg/$normalized.jpg"
+        convert "pictures-png/$normalized.png" -resize 65536@\> "pictures-png/$normalized.png"
         # transfer license and author tags to jpg
         exiftool -overwrite_original -tagsfromfile "pictures-png/$normalized.png" "pictures-jpg/$normalized.jpg"
     fi


### PR DESCRIPTION
This reduces the size for the resulting pngs as well.

PNG is therefore an option which does not have the side-effects of SVG as mentioned in https://github.com/freifunk-darmstadt/gluon-firmware-selector/pull/155#issuecomment-1820869873

Yet it is still smaller than the SVGs, but not as small as the JPGs as the PNGs contain an alpha channel for transparency to support https://github.com/freifunk-darmstadt/gluon-firmware-selector/pull/168

```
Total folder sizes after conversion
2.7M	pictures-jpg
3.1M	pictures-png
4.4M	pictures-svg
```